### PR TITLE
Changed rubocop version for Hound again

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 rubocop:
   config_file: .rubocop.yml
-  version: 1.20.0
+  version: 1.5.2


### PR DESCRIPTION
Changed rubocop configuration in .hound.yml to use the last supported version.